### PR TITLE
Pass through value of curl argument

### DIFF
--- a/R/ROauth.R
+++ b/R/ROauth.R
@@ -116,7 +116,7 @@ setRefClass("OAuth",
                 httpFunc(URLencode(URL), params=params, consumerKey=.self$consumerKey,
                          consumerSecret=.self$consumerSecret,
                          oauthKey=.self$oauthKey, oauthSecret=.self$oauthSecret,
-                         customHeader.self$customHeader, curl=getCurlHandle(), signMethod=.self$signMethod, ...)
+                         customHeader.self$customHeader, curl=curl, signMethod=.self$signMethod, ...)
               }
               )
             )


### PR DESCRIPTION
Make use of the `curl=` argument that is passed to `OAuthRequest()`.  Previously it was using `getCurlHandle()` regardless of what the user passed in.
