### PR TITLE
Read verifier string using readLines()

### DIFF
--- a/R/ROauth.R
+++ b/R/ROauth.R
@@ -56,7 +56,8 @@ setRefClass("OAuth",
                   if (browseUrl) {
                     browseURL(verifyURL)
                   }
-                  .self$verifier <- readline(prompt=msg)
+                  cat(msg)
+                  .self$verifier <- readLines("stdin", 1)
                 }
                 params <- c(oauth_verifier=.self$verifier)
                 resp <- oauthPOST(.self$accessURL, .self$consumerKey, .self$consumerSecret,


### PR DESCRIPTION
If the verifier string is read using `readline()` then it is not possible to use ROAuth in an R script that is launched from an interactive shell terminal.

For example `R -f script.r` fails with `Error: Unauthorized` because `readline()` immediately returns an empty string. This is because R detects it is running from a non-interactive R session.

By using `readLines("stdin, 1")` instead, R will instead prompt for input.
